### PR TITLE
Catch all type of exceptions on post retrieve hook (bluebird catch in…

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -1069,7 +1069,7 @@ Model.prototype._parse = function(data, ungroup) {
       if (promises.length > 0) {
         Promise.all(promises).then(function() {
           resolve(data);
-        }).error(reject);
+        }).catch(reject);
       }
       else {
         resolve(data);
@@ -1178,7 +1178,7 @@ Model.prototype._parse = function(data, ungroup) {
         if (promises.length > 0) {
           Promise.all(promises).then(function() {
             resolve(result)
-          }).error(reject);
+          }).catch(reject);
         }
         else {
           resolve(result);
@@ -1224,7 +1224,7 @@ Model.prototype._parse = function(data, ungroup) {
             if (promise instanceof Promise) {
               promise.then(function() {
                 resolve(newDoc)
-              }).error(function(err) {
+              }).catch(function(err) {
                 reject(err)
               });
             }


### PR DESCRIPTION
The post retrieve hook promise still doesn't catch all exceptions causing unhandled rejected promise errors. This should fix that by using catch instead of error when handling the hook promise rejection.